### PR TITLE
[WIP] Add generic interfaces

### DIFF
--- a/src/bopt.ml
+++ b/src/bopt.ml
@@ -19,7 +19,7 @@ TODO:
 
 type 'a t = 'a option
 
-let make x = Some x
+let of_ x = Some x
 
 let fromList = function
   | x::_ -> Some x
@@ -82,6 +82,14 @@ let getLazy defaultFn = function
 let forEach f = function
   | None -> ()
   | Some x -> f x
+
+let find p = function
+  | Some x when p x -> Some x
+  | _ -> None
+
+let findOrRaise p = function
+  | Some x when p x -> x
+  | _ -> raise Not_found
 
 let map f = function
   | None -> None

--- a/src/bopt.mli
+++ b/src/bopt.mli
@@ -8,8 +8,14 @@ type +'a t = 'a option
 
 (** {2 Construction} *)
 
+include Mappable.S with type 'a t := 'a t
+include Applyable.S with type 'a t := 'a t
+include Reduceable.S with type 'a t := 'a t
+include Monad.S with type 'a t := 'a t
+include Iterable.S with type 'a t := 'a t
+
 (* was return *)
-val make : 'a -> 'a t
+(*val of_ : 'a -> 'a t*)
 (** [make x] is [Some x] *)
 
 val fromList : 'a list -> 'a t
@@ -70,10 +76,10 @@ val getLazy : (unit -> 'a) -> 'a t -> 'a
 
 (** {2 Iteration} *)
 
-val forEach : ('a -> unit) -> 'a t -> unit
+(*val forEach : ('a -> unit) -> 'a t -> unit*)
 (** [forEach f a] calls [f x] if [a] is [Some x] *)
 
-val map : ('a -> 'b) -> 'a t -> 'b t
+(*val map : ('a -> 'b) -> 'a t -> 'b t*)
 (** [map f a] is [Some (f x)] if [a] is [Some x], [None] otherwise *)
 
 val mapOr : default:'b -> ('a -> 'b) -> 'a t -> 'b
@@ -92,19 +98,19 @@ val map2 : ('a -> 'b -> 'c) -> 'a t -> 'b t -> 'c t
     [None] otherwise *)
 
 (* alternative name: andThen *)
-val flatMap : ('a -> 'b t) -> 'a t -> 'b t
+(*val flatMap : ('a -> 'b t) -> 'a t -> 'b t*)
 (** [flatMap f a] is [f x] is [a] is [Some x], [None] otherwise *)
 
-val reduce : ('b -> 'a -> 'b) -> 'b -> 'a t -> 'b
+(*val reduce : ('b -> 'a -> 'b) -> 'b -> 'a t -> 'b*)
 (** [reduce f initial a] is [f inital x] if [a] is [Some x], [initial] otherwise *)
 
-val filter : ('a -> bool) -> 'a t -> 'a t
+(*val filter : ('a -> bool) -> 'a t -> 'a t*)
 (** [filter f a] is [a] if [a] is [Some x] and [f x] is [true], [None] otherwise *)
 
 (** {2 Applicative} *)
 
 (* was (<*>) *)
-val apply : ('a -> 'b) t -> 'a t -> 'b t
+(*val apply : ('a -> 'b) t -> 'a t -> 'b t*)
 (** [apply maybeF a] is [Some (f x)] if [maybeF] is [Some f] and [a] is [Some x],
     [None] otherwise *)
 
@@ -138,10 +144,10 @@ val any : 'a t list -> 'a t
 (** {2 Quantification} *)
 (** TODO: too mathy? *)
 
-val exists : ('a -> bool) -> 'a t -> bool
+(*val exists : ('a -> bool) -> 'a t -> bool*)
 (** [exists f a] is [f x] if [a] is [Some x], [false] otherwise *)
 
-val forAll : ('a -> bool) -> 'a t -> bool
+(*val forAll : ('a -> bool) -> 'a t -> bool*)
 (** [forAll f a] is [f x] if [a] is [Some x], [true] otherwise *)
 
 (** {2 Conversion} *)

--- a/src/core/applyable.mli
+++ b/src/core/applyable.mli
@@ -1,0 +1,24 @@
+(*
+  Gramatically correct: Applicable
+  Haskell: Applicative
+  Fantasyland: Applicative
+*)
+
+module type S = sig
+  type 'a t
+
+  include Mappable.S with type 'a t := 'a t
+
+  (*
+    Haskell: ??
+    Fantasyland: ap (Apply category)
+  *)
+  val apply : ('a -> 'b) t -> 'a t -> 'b t
+
+  (*
+    Alternative names: ofValue, fromValue, from
+    Haskell: pure (return)
+    Fantasyland: of
+  *)
+  val of_ : 'a -> 'a t
+end

--- a/src/core/bounded.ml
+++ b/src/core/bounded.ml
@@ -1,6 +1,0 @@
-
-module type S = sig
-  type t
-  val minValue: t
-  val maxValue: t
-end

--- a/src/core/comparable.ml
+++ b/src/core/comparable.ml
@@ -1,7 +1,0 @@
-module type S = sig
-  type t
-
-  include Equatable.S with type t := t
-
-  val compare:t Comparator.t
-end

--- a/src/core/comparable.mli
+++ b/src/core/comparable.mli
@@ -5,6 +5,6 @@ module type S = sig
 
   include Equatable.S with type t := t
 
-  val compare:t Comparator.t
+  val compare : t Comparator.t
 end
 

--- a/src/core/equatable.ml
+++ b/src/core/equatable.ml
@@ -1,5 +1,0 @@
-
-module type S  = sig 
-  type t 
-  val equals : t Equality.t 
-end

--- a/src/core/equatable.mli
+++ b/src/core/equatable.mli
@@ -1,6 +1,6 @@
 (** Represents modules have equality *)
 
-module type S  = sig 
+module type S = sig 
   type t 
   val equals : t Equality.t 
 end

--- a/src/core/hashable.ml
+++ b/src/core/hashable.ml
@@ -1,5 +1,0 @@
-
-module type S = sig
-    type t
-    val hash: t -> int
-end

--- a/src/core/iterable.mli
+++ b/src/core/iterable.mli
@@ -1,0 +1,34 @@
+
+module type S = sig
+  type 'a t
+
+  (*
+    imm.re: every
+  *)
+  val forAll : ('a -> bool) -> 'a t -> bool
+
+  val find : ('a -> bool) -> 'a t -> 'a option
+
+  val findOrRaise : ('a -> bool) -> 'a t -> 'a
+
+  (*
+    imm.re: let forEach: while_::(elt 'a => bool)? => (elt 'a => unit) => t 'a => unit;
+  *)
+  val forEach : ('a -> unit) -> 'a t -> unit
+
+  (*
+    Superfluous? It's just the inversion of forAll
+
+  val none : ('a -> bool) -> 'a t -> bool
+  *)
+
+  (*
+    imm.re: some
+  *)  
+  val exists : ('a -> bool) -> 'a t -> bool
+
+  (*
+    not in imm.re
+  *)
+  val filter : ('a -> bool) -> 'a t -> 'a t
+end

--- a/src/core/mappable.mli
+++ b/src/core/mappable.mli
@@ -1,0 +1,14 @@
+(*
+  Haskell: Functor
+  Fantasyland: Functor
+*)
+
+module type S = sig
+  type 'a t
+
+  (*
+    Haskell: fmap
+    Fantasyland: map
+  *)
+  val map : ('a -> 'b) -> 'a t -> 'b t
+end

--- a/src/core/monad.mli
+++ b/src/core/monad.mli
@@ -1,0 +1,13 @@
+
+module type S = sig
+  type 'a t
+
+  include Applyable.S with type 'a t := 'a t
+
+  (*
+    Laternative names: andThen
+    Haskell: >>= (bind)
+    Fantasyland: chain (Chain category)
+  *)
+  val flatMap : ('a -> 'b t) -> 'a t -> 'b t
+end

--- a/src/core/reduceable.mli
+++ b/src/core/reduceable.mli
@@ -1,0 +1,16 @@
+(*
+  Gramatically correct: Reducible
+  Haskell: Foldable
+  Fantasyland: Foldable
+*)
+
+module type S = sig
+  type 'a t
+
+  (*
+    Alternative names: fold
+    Haskell: fold
+    Fantasyland: reduce
+  *)
+  val reduce : ('b -> 'a -> 'b) -> 'b -> 'a t -> 'b
+end

--- a/src/core/stringifiable.ml
+++ b/src/core/stringifiable.ml
@@ -1,5 +1,0 @@
-
-module type S = sig
-    type t
-    val toString: t -> string
-end

--- a/tests/bopt_test.ml
+++ b/tests/bopt_test.ml
@@ -5,8 +5,8 @@ open Result
 
 let suite =
   describe "Bopt" (fun () -> [
-    test "make" (fun () ->
-      make 42
+    test "of_" (fun () ->
+      of_ 42
         |> Expect.toEqual (Some 42));
 
     test "fromList - []" (fun () ->
@@ -141,6 +141,28 @@ let suite =
       let xs = ref [] in
       None |> forEach (fun x -> xs := x :: !xs);
       !xs |> Expect.toEqual []);
+
+    test "find - Some _, true" (fun () ->
+      Some 7 |> find (fun x -> x == 7)
+             |> Expect.toEqual (Some 7));
+    test "find - Some _, false" (fun () ->
+      Some 7 |> find (fun x -> x <> 7)
+             |> Expect.toEqual (None));
+    test "find - None" (fun () ->
+      None |> find (fun _ -> true)
+           |> Expect.toEqual None);
+
+    test "findOrRaise - Some _, true" (fun () ->
+      Some 7 |> findOrRaise (fun x -> x == 7)
+             |> Expect.toEqual 7);
+    test "findOrRaise - Some _, false" (fun () ->
+      (fun  () ->
+        Some 7 |> findOrRaise (fun x -> x <> 7))
+               |> Expect.toRaise);
+    test "findOrRaise - None" (fun () ->
+      (fun  () ->
+        None |> findOrRaise (fun _ -> true))
+             |> Expect.toRaise);
 
     test "map - Some _" (fun () ->
       Some 7 |> map (( * ) 3)


### PR DESCRIPTION
This is primarily intended to kick off some discussion on interface design, genericness and consistency across the codebase.

As is probably evident from the interfaces I've added so far, I'm more concerned with practicality than I am with theoretical purity. The names have been chosen to be mnemonic rather than familiar or even grammatically correct, and several traditional categories have been merged into others.

A few questions to consider:
* Should it be more or less granular? Unless there is a practical use case for a separate category I'd rather have duplication.
* How do we separate the basic properties of a category the convenience functions that can be derived from those properties?
* Can we provide generic implementations for those convenience functions? (Immutable.re should be able to provide plenty of inspiration here, but which tradeoffs are there to that approach?)
* And of course naming, which I'm sure we can bikeshed to no end, so perhaps we should try to keep to general principles.

cc @bordoley @bassjacob 